### PR TITLE
Monkeypatch pickle generation to use a temp directory.

### DIFF
--- a/fissix/__init__.py
+++ b/fissix/__init__.py
@@ -5,13 +5,15 @@
 Monkeypatches to override default behavior of lib2to3.
 """
 
+import logging
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 from appdirs import user_cache_dir
 
-from .pgen2 import driver
+from .pgen2 import driver, grammar, pgen
 
 __version__ = "19.2b1"
 __base_version__ = "3.8.0a2+"
@@ -27,4 +29,29 @@ def _generate_pickle_name(gt):
     return (CACHE_DIR / filename).as_posix()
 
 
+def load_grammar(gt="Grammar.txt", gp=None, save=True, force=False, logger=None):
+    """Load the grammar (maybe from a pickle)."""
+    if logger is None:
+        logger = logging.getLogger()
+    gp = _generate_pickle_name(gt) if gp is None else gp
+    if force or not driver._newer(gp, gt):
+        logger.info("Generating grammar tables from %s", gt)
+        g = pgen.generate_grammar(gt)
+        if save:
+            logger.info("Writing grammar tables to %s", gp)
+            # Change here...
+            with tempfile.TemporaryDirectory(dir=os.path.dirname(gp)) as d:
+                tempfilename = os.path.join(d, os.path.basename(gp))
+                try:
+                    g.dump(tempfilename)
+                    os.rename(tempfilename, gp)
+                except OSError as e:
+                    logger.info("Writing failed: %s", e)
+    else:
+        g = grammar.Grammar()
+        g.load(gp)
+    return g
+
+
 driver._generate_pickle_name = _generate_pickle_name
+driver.load_grammar = load_grammar


### PR DESCRIPTION
When multiple processes call load_grammar simultaneously and the pickle doesn't
already exist (such as on CI), they race and one can see a half-written pickle
since it was previously written in its final location.

Writes into a subdirectory that in most cases will be on the same mount as the
destination so atomic renames work.

When the tempdir is on a different mount (e.g. because there are symlinks) the
cache will fail to be written in its final location; same for Windows if the
destination exists due to a race.