### PR TITLE
include dict in iterating context

### DIFF
--- a/fissix/fixer_util.py
+++ b/fissix/fixer_util.py
@@ -251,7 +251,7 @@ p0 = """for_stmt< 'for' any 'in' node=any ':' any* >
      """
 p1 = """
 power<
-    ( 'iter' | 'list' | 'tuple' | 'sorted' | 'set' | 'sum' |
+    ( 'iter' | 'list' | 'tuple' | 'sorted' | 'set' | 'sum' | 'dict' |
       'any' | 'all' | 'enumerate' | (any* trailer< '.' 'join' >) )
     trailer< '(' node=any ')' >
     any*


### PR DESCRIPTION
see-also https://github.com/python-modernize/python-modernize/pull/149

### Description

There is a bug in 2to3 which causes calls like zip to be wrapped in a list when
being passed into a dict constructor. This is not needed.
```
dict(zip(foo))
dict(list(zip(foo)))
```