### PR TITLE
enable pytest strict options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,9 @@ exclude = [
 [tool.black]
 # try to remove this after future black updates
 exclude = "py3_test_grammar.py"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+xfail_strict=true
+addopts = "--strict-markers --strict-config"
+filterwarnings = ["error"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 black
 flit
 isort
-pytest
+pytest>=6.0.1


### PR DESCRIPTION
### Description

currently the `@pytest.mark.xfail` marked tests are free to pass or fail, but we want to know if they did pass so we can remove the mark

Fixes: #
