### PR TITLE
Fixed long getting converted to int when used as a keyword argument

### DIFF
--- a/fissix/fixer_util.py
+++ b/fissix/fixer_util.py
@@ -302,7 +302,7 @@ def is_probably_builtin(node):
         # Assignment.
         return False
     if parent.type == syms.parameters or (
-        parent.type == syms.typedargslist
+        parent.type in (syms.typedargslist, syms.argument)
         and (
             (prev is not None and prev.type == token.COMMA)
             or parent.children[0] is node

--- a/fissix/tests/test_fixers.py
+++ b/fissix/tests/test_fixers.py
@@ -1185,6 +1185,11 @@ class Test_long(FixerTestCase):
         a = """z = type(x) in (int, int)"""
         self.check(b, a)
 
+    def test_4(self):
+        b = """f(arg=long)"""
+        a = """f(arg=int)"""
+        self.check(b, a)
+
     def test_unchanged(self):
         s = """long = True"""
         self.unchanged(s)
@@ -1205,6 +1210,9 @@ class Test_long(FixerTestCase):
         self.unchanged(s)
 
         s = """def f(x, long=True): pass"""
+        self.unchanged(s)
+
+        s = """f(long=True)"""
         self.unchanged(s)
 
     def test_prefix_preservation(self):


### PR DESCRIPTION
### Description

Currently a call to a function that uses `long` as the name of a keyword argument (eg `f(long=True)`) will cause the keyword argument itself to get converted to `int` (eg `f(int=True)`). This changes fixes this case so that the keyword remains as `long`.
