### PR TITLE
Allow tests to be run out of the source tree

### DIFF
--- a/fissix/tests/pytree_idempotency.py
+++ b/fissix/tests/pytree_idempotency.py
@@ -17,9 +17,9 @@ import sys
 import logging
 
 # Local imports
-from .. import pytree
-from .. import pgen2
-from ..pgen2 import driver
+from fissix import pytree
+from fissix import pgen2
+from fissix.pgen2 import driver
 
 logging.basicConfig()
 

--- a/fissix/tests/test_fixers.py
+++ b/fissix/tests/test_fixers.py
@@ -7,7 +7,7 @@ from operator import itemgetter
 
 # Local imports
 from fissix import pygram, fixer_util
-from fissix.tests import support
+from . import support
 
 
 class FixerTestCase(support.TestCase):
@@ -1848,7 +1848,7 @@ class ImportsFixerTests:
 
 class Test_imports(FixerTestCase, ImportsFixerTests):
     fixer = "imports"
-    from ..fixes.fix_imports import MAPPING as modules
+    from fissix.fixes.fix_imports import MAPPING as modules
 
     def test_multiple_imports(self):
         b = """import urlparse, cStringIO"""
@@ -1869,16 +1869,16 @@ class Test_imports(FixerTestCase, ImportsFixerTests):
 
 class Test_imports2(FixerTestCase, ImportsFixerTests):
     fixer = "imports2"
-    from ..fixes.fix_imports2 import MAPPING as modules
+    from fissix.fixes.fix_imports2 import MAPPING as modules
 
 
 class Test_imports_fixer_order(FixerTestCase, ImportsFixerTests):
     def setUp(self):
         super(Test_imports_fixer_order, self).setUp(["imports", "imports2"])
-        from ..fixes.fix_imports2 import MAPPING as mapping2
+        from fissix.fixes.fix_imports2 import MAPPING as mapping2
 
         self.modules = mapping2.copy()
-        from ..fixes.fix_imports import MAPPING as mapping1
+        from fissix.fixes.fix_imports import MAPPING as mapping1
 
         for key in ("dbhash", "dumbdbm", "dbm", "gdbm"):
             self.modules[key] = mapping1[key]
@@ -1891,7 +1891,7 @@ class Test_imports_fixer_order(FixerTestCase, ImportsFixerTests):
 
 class Test_urllib(FixerTestCase):
     fixer = "urllib"
-    from ..fixes.fix_urllib import MAPPING as modules
+    from fissix.fixes.fix_urllib import MAPPING as modules
 
     def test_import_module(self):
         for old, changes in self.modules.items():

--- a/fissix/tests/test_parser.py
+++ b/fissix/tests/test_parser.py
@@ -27,7 +27,7 @@ import pytest
 # Local imports
 from fissix.pgen2 import driver as pgen2_driver
 from fissix.pgen2 import tokenize
-from ..pgen2.parse import ParseError
+from fissix.pgen2.parse import ParseError
 from fissix.pygram import python_symbols as syms
 
 


### PR DESCRIPTION
Debian has [autopkgtests](https://salsa.debian.org/ci-team/autopkgtest/raw/master/doc/README.package-tests.rst) that can run package test suites against the installed version of the package to prove that it was installed successfully. They also help to prove that the dependencies remain compatible.

Upstream unit tests are usually run by running the tests outside the source tree. This is trivial when tests are in a separate module.

Fissix's tests are within the `fissix` module. Many imports would work correctly outside source tree, but relative imports between the test and source packages need to be made explicit.

Would you be willing to carry this patch to allow Debian to run your unit tests more frequently? In future merges from lib2to3, I'd imagine more care would need to be taken to keep the imports separate.

Closes: #30.