### PR TITLE
except fixer: don't do anything if the "as" is already there

### DIFF
--- a/fissix/fixes/fix_except.py
+++ b/fissix/fixes/fix_except.py
@@ -54,7 +54,7 @@ class FixExcept(fixer_base.BaseFix):
         try_cleanup = [ch.clone() for ch in results["cleanup"]]
         changed = False
         for except_clause, e_suite in find_excepts(try_cleanup):
-            if len(except_clause.children) == 4:
+            if len(except_clause.children) == 4 and except_clause.children[2] != "as":
                 (E, comma, N) = except_clause.children[1:4]
                 comma.replace(Name("as", prefix=" "))
                 changed = True


### PR DESCRIPTION
### Description

except fixer is saying there are changes but there are not, in the case where the "as" is already there. It's because it's not looking to see whether it is an "as" already, before going ahead and changing it to "as".

Fixes: #37
